### PR TITLE
use http for zip downloads

### DIFF
--- a/web/toolbelt.rb
+++ b/web/toolbelt.rb
@@ -202,13 +202,13 @@ class Toolbelt < Sinatra::Base
   get "/download/zip" do
     log_download(request)
     record_hit "zip"
-    redirect "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client.zip"
+    redirect "http://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client.zip"
   end
 
   get "/download/beta-zip" do
     log_download(request)
     record_hit "zip"
-    redirect "https://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-beta.zip"
+    redirect "http://s3.amazonaws.com/assets.heroku.com/heroku-client/heroku-client-beta.zip"
   end
 
   # linux install instructions


### PR DESCRIPTION
the CLI verifies the hash of the file, so this is still secure. The real reason for this is because windows s3 ssl updates have been failing the last couple of days. I'm still not sure why, but this will at least fix existing clients.